### PR TITLE
Bump python to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER Abakus Webkom <webkom@abakus.no>
 
 RUN pip install tox


### PR DESCRIPTION
**TL;DR UPDATE**: I built this image locally and pushed to dockerhub under the `:test` tag, and it doesn't really work 🔥I don't think `make` is located in the `-alpine` image
https://ci.abakus.no/webkom/lego/2785/5

**TL;DR UPDATE 2** I buildt the image without alpine and pushed it as `:python3.7`. We are trying to get [this branch](https://github.com/webkom/lego/pull/1555) to pass with the new python version. And the [last run](https://ci.abakus.no/webkom/lego/2794) passed like a charm

The 'real' tox image is running 3.7 with alpine, so we should be able to do the same https://hub.docker.com/r/younata/tox

![image](https://user-images.githubusercontent.com/23152018/56416544-76894b80-6291-11e9-8358-be96e3dd68f6.png)